### PR TITLE
fix: 修复在 Windows 下执行 python manage.py gen_all 命令出现编码错误的bug #2

### DIFF
--- a/tyadmin_api_cli/deal_antd_pages.py
+++ b/tyadmin_api_cli/deal_antd_pages.py
@@ -768,7 +768,7 @@ def gen_antd_pages(project_name_settings, user_label_list, focus_model=None, tem
             opera = opera.replace("$时间处理占位$", "".join(date_row_list))
             columns.append(opera)
             dest_path = f'{os.path.dirname(__file__)}/antd_page_templates/{template_type}'
-            with open(f'{dest_path}/index.jsx') as fr:
+            with open(f'{dest_path}/index.jsx', encoding='utf-8') as fr:
 
                 content = fr.read()
                 if fileds_num > 8:
@@ -872,7 +872,7 @@ def gen_antd_pages(project_name_settings, user_label_list, focus_model=None, tem
                     new_content = new_content.replace("$Password占位$", '')
                     new_content = new_content.replace("$更新密码方法占位$", '')
                     new_content = new_content.replace("$Password更新Form$", '')
-            with open(f'{dest_path}/service.js') as fr:
+            with open(f'{dest_path}/service.js', encoding='utf-8') as fr:
                 content = fr.read()
 
                 new_services = content.replace("$占位path$", get_lower_case_name(model_name))
@@ -889,21 +889,21 @@ export async function updateUserPassword(params) {
 }""")
                 else:
                     new_services = new_services.replace("$更新密码service占位$", "")
-            with open(f'{dest_path}/components/CreateForm.jsx') as fr:
+            with open(f'{dest_path}/components/CreateForm.jsx', encoding='utf-8') as fr:
                 create_form = fr.read()
                 create_form = create_form.replace("$占位模型显示名$", str(model_ver_name))
                 if fileds_num > 8:
                     create_form = create_form.replace("$宽度占位$", 'width={1200}')
                 else:
                     create_form = create_form.replace("$宽度占位$", "width={800}")
-            with open(f'{dest_path}/components/UpdateForm.jsx') as fr:
+            with open(f'{dest_path}/components/UpdateForm.jsx', encoding='utf-8') as fr:
                 update_form = fr.read()
                 update_form = update_form.replace("$占位模型显示名$", str(model_ver_name))
                 if fileds_num > 8:
                     update_form = update_form.replace("$宽度占位$", 'width={1200}')
                 else:
                     update_form = update_form.replace("$宽度占位$", "width={800}")
-            with open(f'{dest_path}/components/UpdatePasswordForm.jsx') as fr:
+            with open(f'{dest_path}/components/UpdatePasswordForm.jsx', encoding='utf-8') as fr:
                 change_password_form = fr.read()
 
             target_path = f'{settings.BASE_DIR}/tyadmin/src/pages/AutoGenPage'
@@ -913,16 +913,16 @@ export async function updateUserPassword(params) {
             cur_path_co = f'{target_path}/{model_name}List/components'
             if not os.path.exists(cur_path_co):
                 os.mkdir(cur_path_co)
-            with open(f'{target_path}/{model_name}List/index.jsx', 'w') as fw:
+            with open(f'{target_path}/{model_name}List/index.jsx', 'w', encoding='utf-8') as fw:
                 fw.write(new_content)
-            with open(f'{target_path}/{model_name}List/service.js', 'w') as fw:
+            with open(f'{target_path}/{model_name}List/service.js', 'w', encoding='utf-8') as fw:
                 fw.write(new_services)
-            with open(f'{target_path}/{model_name}List/components/CreateForm.jsx', 'w') as fw:
+            with open(f'{target_path}/{model_name}List/components/CreateForm.jsx', 'w', encoding='utf-8') as fw:
                 fw.write(create_form)
-            with open(f'{target_path}/{model_name}List/components/UpdateForm.jsx', 'w') as fw:
+            with open(f'{target_path}/{model_name}List/components/UpdateForm.jsx', 'w', encoding='utf-8') as fw:
                 fw.write(update_form)
             if one._meta.app_label == user._meta.app_label:
-                with open(f'{target_path}/{model_name}List/components/UpdatePasswordForm.jsx', 'w') as fw:
+                with open(f'{target_path}/{model_name}List/components/UpdatePasswordForm.jsx', 'w', encoding='utf-8') as fw:
                     fw.write(change_password_form)
 
 

--- a/tyadmin_api_cli/gen_filter.py
+++ b/tyadmin_api_cli/gen_filter.py
@@ -85,7 +85,7 @@ class {model}Filter(filters.FilterSet):
     # if os.path.exists(f'{settings.BASE_DIR}/tyadmin_api/auto_filters.py'):
     #     print("已存在filters.py跳过")
     # else:
-    with open(f'{settings.BASE_DIR}/tyadmin_api/auto_filters.py', 'w') as fw:
+    with open(f'{settings.BASE_DIR}/tyadmin_api/auto_filters.py', 'w', encoding='utf-8') as fw:
         fw.write(filters_txt)
 
 

--- a/tyadmin_api_cli/gen_serializer.py
+++ b/tyadmin_api_cli/gen_serializer.py
@@ -136,7 +136,7 @@ $model_import占位$"""
     # if os.path.exists(f'{settings.BASE_DIR}/tyadmin_api/auto_serializers.py'):
     #     print("已存在serializers跳过")
     # else:
-    with open(f'{settings.BASE_DIR}/tyadmin_api/auto_serializers.py', 'w') as fw:
+    with open(f'{settings.BASE_DIR}/tyadmin_api/auto_serializers.py', 'w', encoding='utf-8') as fw:
         fw.write(serializers_txt)
 
 

--- a/tyadmin_api_cli/gen_url.py
+++ b/tyadmin_api_cli/gen_url.py
@@ -40,7 +40,7 @@ urlpatterns = [
     # if os.path.exists(f'{settings.BASE_DIR}/tyadmin_api/auto_url.py'):
     #     print("已存在urls跳过")
     # else:
-    with open(f'{settings.BASE_DIR}/tyadmin_api/auto_url.py', 'w') as fw:
+    with open(f'{settings.BASE_DIR}/tyadmin_api/auto_url.py', 'w', encoding='utf-8') as fw:
         fw.write(url_txt)
 
 

--- a/tyadmin_api_cli/gen_view.py
+++ b/tyadmin_api_cli/gen_view.py
@@ -73,7 +73,7 @@ class {model_name}ViewSet(XadminViewSet):
     # if os.path.exists(f'{settings.BASE_DIR}/tyadmin_api/auto_views.py'):
     #     print("已存在views跳过")
     # else:
-    with open(f'{settings.BASE_DIR}/tyadmin_api/auto_views.py', 'w') as fw:
+    with open(f'{settings.BASE_DIR}/tyadmin_api/auto_views.py', 'w', encoding='utf-8') as fw:
         fw.write(viewset_txt)
 
 


### PR DESCRIPTION
同时给所有调用 `open() ` 的函数都添加 `encoding='utf-8'` 参数